### PR TITLE
Convert  latitude and longitude values from BSM JSON to float type, fix UI errors and improve map background contrast

### DIFF
--- a/MapUI/MapWidget/mapwidget.py
+++ b/MapUI/MapWidget/mapwidget.py
@@ -135,7 +135,7 @@ class MapWidget(QWidget):
         Adds the vehicle position to the map
         '''
         self.clearVehiclePosition()
-        x, y = self._convertCoords(long, lat)
+        x, y = self._convertCoords(float(long), float(lat))
         vehicle = VehicleGI(x, y, self.scene)
         self.vehicle_position = vehicle
         self.scene.addItem(vehicle)

--- a/MapUI/MapWidget/mapwidget.py
+++ b/MapUI/MapWidget/mapwidget.py
@@ -118,6 +118,8 @@ class MapWidget(QWidget):
         '''
         Takes an action point dictionary and adds the action point to the map
         '''
+        if long is None or lat is None:
+            return
         x, y = self._convertCoords(long, lat)
         ap = ActionPointGI(x, y, self.scene)
         self.ap_list.append(ap)

--- a/MapUI/actionPointItem.py
+++ b/MapUI/actionPointItem.py
@@ -63,7 +63,10 @@ class ActionPointModel(QAbstractListModel):
             return ap
 
         if role == Qt.ItemDataRole.DisplayRole: # Completed list display
-            text = ap.actionPoint.completedActionPointDisplay()
+            if hasattr(ap, "actionPoint"):
+                text = ap.actionPoint.completedActionPointDisplay()
+            else:
+                text = ap.completedActionPointDisplay()
             return text
 
     def setData(self, index, value, role):
@@ -73,7 +76,6 @@ class ActionPointModel(QAbstractListModel):
         # if role != Qt.ItemDataRole.EditRole:
         #     print("Not editable")
         #     return False
-
 
         self.actions[index.row()] = value
         self.dataChanged.emit(index, index)
@@ -109,7 +111,6 @@ class ActionPointModel(QAbstractListModel):
             return False
         self.actions = [self.actions[i] for i in index_list]
         return True
-
 
     def supportedDropActions(self):
         return Qt.DropAction.MoveAction
@@ -161,8 +162,7 @@ class ActionPointModel(QAbstractListModel):
 
         self.insertRows(beginRow, count=1, parent=parent)
 
-        #json_list = json.load(stream.readQStringList())
-
+        # json_list = json.load(stream.readQStringList())
 
         for json_str in stream.readQStringList():
             index = self.index(beginRow, 0, parent)
@@ -179,9 +179,8 @@ class ActionPointModel(QAbstractListModel):
             self.setData(index, ap, role=Qt.ItemDataRole.EditRole)
             beginRow+=1
 
-
         return True
-        #return super().dropMimeData(data, action, row, column, parent)
+        # return super().dropMimeData(data, action, row, column, parent)
 
     def convertToDataframe(self):
         '''
@@ -208,7 +207,7 @@ class ActionPointModel(QAbstractListModel):
     def flags(self, index):
         flags = super().flags(index)
         # if self.loadingActions[index.row()].status != "Completed":
-            # |= is a special operator required to add a new flag to the list of flags
+        # |= is a special operator required to add a new flag to the list of flags
         flags |= Qt.ItemFlag.ItemIsEditable
 
         if index.isValid():


### PR DESCRIPTION
Here is the sample BSM JSON received by the map UI, the longitude and latitude values in the JSON are of string data type. However, the UI itself assumed it was numeric value, thus throw error when using the values as it for calculation. This PR is to convert the latitude and longitude data type to float before being used.
`Received message: {"BasicSafetyMessage":{"coreData":{"id":"67458b6b","msgCnt":"117","secMark":"24440","lat":"389565434","long":"-771500475","elev":"745","accuracy":{"semiMajor":"255","semiMinor":"255","orientation":"65535"},"transmission":{"neutral":""},"speed":"8191","heading":"28800","angle":"127","accelSet":{"yaw":"0","long":"2001","lat":"2001","vert":"-127"},"brakes":{"wheelBrakes":"00000","traction":{"unavailable":""},"abs":{"unavailable":""},"scs":{"unavailable":""},"brakeBoost":{"unavailable":""},"auxBrakes":{"unavailable":""}},"size":{"width":"200","length":"500"}}}}`

This ONLY resolve the error thrown in the terminal when parsing the JSON: https://github.com/VolpeUSDOT/CDA1Tenth/issues/21

Resolve error when clicking on the "Add Action Point" and "Edit Action Point" buttons: https://github.com/VolpeUSDOT/CDA1Tenth/issues/18

Update  the background color contrast: https://github.com/VolpeUSDOT/CDA1Tenth/issues/16